### PR TITLE
Add scheduler tests and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# AutoLogin
+
+This project automates logging in to a website and includes a small scheduler
+UI. Tests are provided using Python's built in `unittest` framework.
+
+## Running tests
+
+Execute the test suite from the project root with:
+
+```bash
+python -m unittest discover tests
+```
+
+This discovers and runs all tests inside the `tests/` directory.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,52 @@
+import os
+import json
+import unittest
+import tempfile
+from unittest.mock import patch
+import types
+import sys
+
+# Create minimal stubs for external dependencies so ui.py can be imported
+_dummy_tk = types.ModuleType('tkinter')
+_dummy_tk.messagebox = types.ModuleType('messagebox')
+_dummy_tk.simpledialog = types.ModuleType('simpledialog')
+_dummy_tk.font = types.ModuleType('font')
+
+sys.modules.setdefault('tkinter', _dummy_tk)
+
+_tkcalendar = types.ModuleType('tkcalendar')
+class Calendar:  # dummy Calendar class
+    pass
+_tkcalendar.Calendar = Calendar
+sys.modules.setdefault('tkcalendar', _tkcalendar)
+
+sys.modules.setdefault('pystray', types.ModuleType('pystray'))
+
+_pil = types.ModuleType('PIL')
+_pil.Image = types.ModuleType('Image')
+_pil.ImageDraw = types.ModuleType('ImageDraw')
+sys.modules.setdefault('PIL', _pil)
+sys.modules.setdefault('PIL.Image', _pil.Image)
+sys.modules.setdefault('PIL.ImageDraw', _pil.ImageDraw)
+
+import ui
+
+class TestSchedulerIO(unittest.TestCase):
+    def test_load_missing_file_returns_empty_dict(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'missing.json')
+            with patch.object(ui, 'SCHEDULE_FILE', path):
+                self.assertEqual(ui.load_schedules(), {})
+
+    def test_save_schedules_writes_data(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'out.json')
+            data = {'2024-01-01': True}
+            with patch.object(ui, 'SCHEDULE_FILE', path):
+                ui.save_schedules(data)
+                with open(path, 'r') as f:
+                    loaded = json.load(f)
+            self.assertEqual(loaded, data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `tests/test_scheduler.py` with unit tests for `load_schedules` and `save_schedules`
- document running the tests via `python -m unittest discover tests`

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_685a2b1bef008325b4305609d47e0358